### PR TITLE
Fix Android hitbox height

### DIFF
--- a/src/editor.html
+++ b/src/editor.html
@@ -1650,6 +1650,7 @@
 				font-family: Arial, Helvetica, sans-serif;
 				font-size:1em;
 				color:#2d4150;
+				height: 100%;
 			}
 
 			body {
@@ -1659,7 +1660,6 @@
 				padding-bottom: 0px;
 				overflow-y: scroll;
 				-webkit-overflow-scrolling: touch;
-				height: 100%;
 			}
 
 			img.zs_active {


### PR DESCRIPTION
Make sure the hitbox makes 100% of the height. Otherwise, we need to press on top left corner to have the focus